### PR TITLE
Fix const attribute mismatch on size function

### DIFF
--- a/features/filesystem/sd/SDBlockDevice.cpp
+++ b/features/filesystem/sd/SDBlockDevice.cpp
@@ -341,7 +341,7 @@ bd_size_t SDBlockDevice::get_erase_size() const
     return 512;
 }
 
-bd_size_t SDBlockDevice::size()
+bd_size_t SDBlockDevice::size() const
 {
     _lock.lock();
     bd_size_t sectors = _sectors;

--- a/features/filesystem/sd/SDBlockDevice.h
+++ b/features/filesystem/sd/SDBlockDevice.h
@@ -119,7 +119,7 @@ public:
      *
      *  @return         Size of the underlying device in bytes
      */
-    virtual bd_size_t size();
+    virtual bd_size_t size() const;
 
     /** Enable or disable debugging
      *
@@ -149,7 +149,7 @@ private:
     unsigned _block_size;
     bool _is_initialized;
     bool _dbg;
-    Mutex _lock;
+    mutable Mutex _lock;
 };
 
 


### PR DESCRIPTION
This is needed to compile with the release of mbed OS. Otherwise constraint is not matched on the member function.

cc @simonqhughes, @c1728p9 