### PR TITLE
Start using mbed_lib.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -538,7 +538,7 @@ The following sample code illustrates how to use the sd-driver Block Device API:
     //     MISO (Master In Slave Out)
     //     SCLK (Serial Clock)
     //     CS (Chip Select)
-    SDBlockDevice sd(p5, p6, p7, p12); // mosi, miso, sclk, cs
+    SDBlockDevice sd(MBED_CONF_SD_SPI_MOSI, MBED_CONF_SD_SPI_MISO, MBED_CONF_SD_SPI_CLK, MBED_CONF_SD_SPI_CS);
     uint8_t block[512] = "Hello World!\n";
     
     int main() 

--- a/config/mbed_lib.json
+++ b/config/mbed_lib.json
@@ -1,4 +1,5 @@
 {
+    "name": "sd",
     "config": {
         "UART_RX": "D0",
         "UART_TX": "D1",

--- a/features/TESTS/examples/example1/example1.cpp
+++ b/features/TESTS/examples/example1/example1.cpp
@@ -8,7 +8,7 @@
 #include "platform/mbed_retarget.h"
 
 
-SDBlockDevice sd(MBED_CONF_APP_SPI_MOSI, MBED_CONF_APP_SPI_MISO, MBED_CONF_APP_SPI_CLK, MBED_CONF_APP_SPI_CS);
+SDBlockDevice sd(MBED_CONF_SD_SPI_MOSI, MBED_CONF_SD_SPI_MISO, MBED_CONF_SD_SPI_CLK, MBED_CONF_SD_SPI_CS);
 FATFileSystem fs("sd", &sd);
 
 void return_error(int ret_val){

--- a/features/TESTS/filesystem/basic/basic.cpp
+++ b/features/TESTS/filesystem/basic/basic.cpp
@@ -120,7 +120,7 @@ static const char *fsfat_basic_bin_filename_test_10 = "0:testfile.bin";
 
 
 
-SDBlockDevice sd(MBED_CONF_APP_SPI_MOSI, MBED_CONF_APP_SPI_MISO, MBED_CONF_APP_SPI_CLK, MBED_CONF_APP_SPI_CS);
+SDBlockDevice sd(MBED_CONF_SD_SPI_MOSI, MBED_CONF_SD_SPI_MISO, MBED_CONF_SD_SPI_CLK, MBED_CONF_SD_SPI_CS);
 FATFileSystem fs(sd_mount_pt, &sd);
 
 #define FSFAT_BASIC_MSG(_buf, _max_len, _fmt, ...)   \

--- a/features/TESTS/filesystem/fopen/fopen.cpp
+++ b/features/TESTS/filesystem/fopen/fopen.cpp
@@ -85,7 +85,7 @@ static char fsfat_fopen_utest_msg_g[FSFAT_UTEST_MSG_BUF_SIZE];
 static const char *sd_badfile_path = "/sd/badfile.txt";
 static const char *sd_testfile_path = "/sd/test.txt";
 
-SDBlockDevice sd(MBED_CONF_APP_SPI_MOSI, MBED_CONF_APP_SPI_MISO, MBED_CONF_APP_SPI_CLK, MBED_CONF_APP_SPI_CS);
+SDBlockDevice sd(MBED_CONF_SD_SPI_MOSI, MBED_CONF_SD_SPI_MISO, MBED_CONF_SD_SPI_CLK, MBED_CONF_SD_SPI_CS);
 FATFileSystem fs("sd", &sd);
 
 #define FSFAT_FOPEN_TEST_01      fsfat_fopen_test_01


### PR DESCRIPTION
Modify example also similarly to match the PIN definitions. This encapsulates
all the SD-card related stuff to this library. By including this library you
also get the pin definitions on the same go.