### PR TITLE
Add UBLOX_EVK_ODIN_W2 override for int. SD-card

### DIFF
--- a/config/mbed_lib.json
+++ b/config/mbed_lib.json
@@ -121,6 +121,12 @@
              "SPI_CLK":  "p15",
              "SPI_CS":   "p14"
         },
+        "UBLOX_EVK_ODIN_W2": {
+            "SPI_CS": "D9",
+            "SPI_MOSI": "D11",
+            "SPI_MISO": "D12",
+            "SPI_CLK": "D13"
+        },
         "RZ_A1H": {
              "SPI_MOSI": "P8_5",
              "SPI_MISO": "P8_6",


### PR DESCRIPTION
Enable the internal SD-card reader in UBLOX_EVK_ODIN_W2. This will
disable the CI-shield SD-card reader if you have, if you prefer using it
you have to remove this target override section.

Please note that there seem to be some reliability problems with the
internal SD-card slot, in my case the mbed OS CI-shield works better.