### PR TITLE
Add checks for '.' and '..' in readdir tests

### DIFF
--- a/TESTS/filesystem/fopen/fopen.cpp
+++ b/TESTS/filesystem/fopen/fopen.cpp
@@ -1105,6 +1105,16 @@ control_t fsfat_fopen_test_12(const size_t call_count)
     pos = strrchr(buf, '/');
     *pos = '\0';
     dir = opendir(buf);
+
+    dp = readdir(dir);
+    TEST_ASSERT_MESSAGE(dp != 0, "Error: readdir() failed\n");
+    FSFAT_TEST_UTEST_MESSAGE(fsfat_fopen_utest_msg_g, FSFAT_UTEST_MSG_BUF_SIZE, "%s:Error: unexpected object name (name=%s, expected=%s).\n", __func__, dp->d_name, ".");
+    TEST_ASSERT_MESSAGE(strncmp(dp->d_name, ".", strlen(".")) == 0, fsfat_fopen_utest_msg_g);
+    dp = readdir(dir);
+    TEST_ASSERT_MESSAGE(dp != 0, "Error: readdir() failed\n");
+    FSFAT_TEST_UTEST_MESSAGE(fsfat_fopen_utest_msg_g, FSFAT_UTEST_MSG_BUF_SIZE, "%s:Error: unexpected object name (name=%s, expected=%s).\n", __func__, dp->d_name, "..");
+    TEST_ASSERT_MESSAGE(strncmp(dp->d_name, "..", strlen("..")) == 0, fsfat_fopen_utest_msg_g);
+
     while ((dp = readdir(dir)) != NULL) {
         FSFAT_DBGLOG("%s: filename: \"%s\"\n", __func__, dp->d_name);
         TEST_ASSERT_MESSAGE(dp != 0, "Error: readdir() failed\n");


### PR DESCRIPTION
This updates the tests to check for '.' and '..', otherwise the tests fail when the expected file is not first in the directory iteration.

Note: This is related to https://github.com/ARMmbed/mbed-os/pull/4186, and should not be merged unless https://github.com/ARMmbed/mbed-os/pull/4186 is.

tested locally with K64F, GCC_ARM
cc @simonqhughes 