### PR TITLE
Modify the access restriction of SDBlockDevice class

### DIFF
--- a/features/filesystem/sd/SDBlockDevice.h
+++ b/features/filesystem/sd/SDBlockDevice.h
@@ -127,7 +127,7 @@ public:
      */
     virtual void debug(bool dbg);
 
-private:
+protected:
     int _cmd(int cmd, int arg);
     int _cmdx(int cmd, int arg);
     int _cmd8();


### PR DESCRIPTION
The access restriction of `SDBlockDevice` class is **private:** .
For that reason, I can not change the value of this class members from outside.
In [SDFilesystem](https://developer.mbed.org/users/mbed_official/code/SDFileSystem/file/8db0d3b02cec/SDFileSystem.h) of mbed classic, the access restriction of this class was **protected:** .
Therefore, I expect that the access restriction is chaged from **private:** to **protected:**.

For example, I would like to change  **_transfer_sck**  from outside by inheriting class. But I cann not change it. I would like to change the clock to about 20 MHz and access it fast.

Also, I would like to change other members as well.
Regarding other libraries, 
For example, [iSDIO](https://developer.mbed.org/users/ban4jp/code/iSDIO/) library inherits  `SDFileSystem`  and uses  **_cmd**,  **_cs** (the access restriction is **protected:**).
But, If  `SDBlockDevice`  instead of  `SDFileSystem`  is inherited, the access restriction is changed to **private:**`  and iSDIO`  library will not work correctly.

Reference issue is here : https://github.com/ARMmbed/sd-driver/issues/3