### PR TITLE
CSD Failure

### DIFF
--- a/SDBlockDevice.cpp
+++ b/SDBlockDevice.cpp
@@ -1010,7 +1010,6 @@ void SDBlockDevice::_select() {
 
 void SDBlockDevice::_deselect() {
     _cs = 1;
-    _spi.write(0xFF);
     _spi.unlock();
 }
 #endif  /* DEVICE_SPI */

--- a/SDBlockDevice.cpp
+++ b/SDBlockDevice.cpp
@@ -369,6 +369,9 @@ int SDBlockDevice::init()
 
 int SDBlockDevice::deinit()
 {
+    _lock.lock();
+    _is_initialized = false;
+    _lock.unlock();
     return 0;
 }
 

--- a/SDBlockDevice.cpp
+++ b/SDBlockDevice.cpp
@@ -344,6 +344,11 @@ int SDBlockDevice::init()
     }
     debug_if(SD_DBG, "init card = %d\n", _is_initialized);
     _sectors = _sd_sectors();
+    // CMD9 failed
+    if (0 == _sectors) {
+        _lock.unlock();
+        return BD_ERROR_DEVICE_ERROR;
+    }
 
     // Set block length to 512 (CMD16)
     if (_cmd(CMD16_SET_BLOCKLEN, _block_size) != 0) {
@@ -358,11 +363,9 @@ int SDBlockDevice::init()
         _lock.unlock();
         return err;
     }
-
     _lock.unlock();
     return BD_ERROR_OK;
 }
-
 
 int SDBlockDevice::deinit()
 {


### PR DESCRIPTION
CMD9 fails for few cards if spi.write is performed during deselect of card.
Card immediately sends start packet token, which goes missing in this dummy write to SPI. Should not clock SPI bus in deselect operation.

Issue #39 