### PR TITLE
Correct calculation of the erase sector size

### DIFF
--- a/SDBlockDevice.cpp
+++ b/SDBlockDevice.cpp
@@ -941,7 +941,7 @@ uint32_t SDBlockDevice::_sd_sectors() {
                 _erase_size = BLOCK_SIZE_HC;
             } else {
                 // ERASE_BLK_EN = 1: Erase in multiple of SECTOR_SIZE supported
-                _erase_size = ext_bits(csd, 45, 39);
+                _erase_size = BLOCK_SIZE_HC * (ext_bits(csd, 45, 39) + 1);
             }
             break;
 


### PR DESCRIPTION
According to the [documentation](http://users.ece.utexas.edu/~valvano/EE345M/SD_Physical_Layer_Spec.pdf) (page 95) you should add one to the value extracted from the CSD to obtain the real erase sector size.