### PR TITLE
Limit erase_size to block_size

### DIFF
--- a/SDBlockDevice.cpp
+++ b/SDBlockDevice.cpp
@@ -942,6 +942,9 @@ uint32_t SDBlockDevice::_sd_sectors() {
             } else {
                 // ERASE_BLK_EN = 1: Erase in multiple of SECTOR_SIZE supported
                 _erase_size = ext_bits(csd, 45, 39);
+                if (_erase_size < _block_size) {
+                    _erase_size = _block_size;
+                }
             }
             break;
 


### PR DESCRIPTION
currently the driver can't take advantage of erase sizes smaller than the block_size. Reporting the true erase size ends up confusing filesystems on top.

related: https://github.com/ARMmbed/mbed-os/issues/4899
cc @deepikabhavnani, @LemonBoy