### PR TITLE
add support for SD card holder on HEXIWEAR base board.

### DIFF
--- a/TESTS/block_device/basic/basic.cpp
+++ b/TESTS/block_device/basic/basic.cpp
@@ -164,7 +164,7 @@ void test_read_write() {
 
 // Test setup
 utest::v1::status_t test_setup(const size_t number_of_cases) {
-    GREENTEA_SETUP(30, "default_auto");
+    GREENTEA_SETUP(120, "default_auto");
     return verbose_test_setup_handler(number_of_cases);
 }
 

--- a/config/mbed_lib.json
+++ b/config/mbed_lib.json
@@ -97,7 +97,7 @@
              "SPI_CLK":  "p13",
              "SPI_CS":   "p14"
         },
-         "NUCLEO_F429ZI": { 
+         "NUCLEO_F429ZI": {
              "SPI_MOSI": "PC_12",
              "SPI_MISO": "PC_11",
              "SPI_CLK":  "PC_10",
@@ -138,6 +138,12 @@
              "SPI_MISO": "P8_6",
              "SPI_CLK":  "P8_3",
              "SPI_CS":   "P8_4"
+        },
+        "HEXIWEAR": {
+             "SPI_MOSI": "PTE3",
+             "SPI_MISO": "PTE1",
+             "SPI_CLK":  "PTE2",
+             "SPI_CS":   "PTE4"
         }
     }
 }


### PR DESCRIPTION
Adding support for the TARGET_HEXIWEAR SD holder on the base board.  Tested using the cloud client example.