### PR TITLE
Add SD card reader support over DISCO_L476VG platform for running Cloud Client.

### DIFF
--- a/config/mbed_lib.json
+++ b/config/mbed_lib.json
@@ -43,6 +43,12 @@
              "SPI_CLK":  "SPI_SCK",
              "SPI_CS":   "SPI_CS"
         },
+        "DISCO_L476VG": {
+          "SPI_MOSI": "PE_15",
+          "SPI_MISO": "PE_14",
+          "SPI_CLK":  "PE_13",
+          "SPI_CS":   "PE_12"
+        },
         "K20D50M": {
              "SPI_MOSI": "PTD2",
              "SPI_MISO": "PTD3",


### PR DESCRIPTION
@MarceloSalazar Add SPI pins setting for support SD card reader/writer over DISCO_L476VG, which is required and tested by using ARMmbed/mbed-cloud-client-example-sources-internal.