### PR TITLE
Should not wait for card to be ready when sending stop command

### DIFF
--- a/SDBlockDevice.cpp
+++ b/SDBlockDevice.cpp
@@ -689,8 +689,12 @@ int SDBlockDevice::_cmd(SDBlockDevice::cmdSupported cmd, uint32_t arg, bool isAc
     // Select card and wait for card to be ready before sending next command
     // Note: next command will fail if card is not ready
     _select();
-    if (false == _wait_ready(SD_COMMAND_TIMEOUT)) {
-        debug_if(SD_DBG, "Card not ready yet \n");
+
+    // No need to wait for card to be ready when sending the stop command
+    if (CMD12_STOP_TRANSMISSION != cmd) {
+        if (false == _wait_ready(SD_COMMAND_TIMEOUT)) {
+            debug_if(SD_DBG, "Card not ready yet \n");
+        }
     }
 
     // Re-try command
@@ -698,11 +702,10 @@ int SDBlockDevice::_cmd(SDBlockDevice::cmdSupported cmd, uint32_t arg, bool isAc
         // Send CMD55 for APP command first
         if (isAcmd) {
             response = _cmd_spi(CMD55_APP_CMD, 0x0);
-        }
-
-        // Wait for card to be ready after CMD55
-        if (false == _wait_ready(SD_COMMAND_TIMEOUT)) {
-            debug_if(SD_DBG, "Card not ready yet \n");
+            // Wait for card to be ready after CMD55
+            if (false == _wait_ready(SD_COMMAND_TIMEOUT)) {
+                debug_if(SD_DBG, "Card not ready yet \n");
+            }
         }
 
         // Send command over SPI interface


### PR DESCRIPTION
Wait for card to be ready is required before sending commands, or performing read/write operations except for CMD12. CMD12 can be sent even if the card is not ready and is used to stop read multiple block operation.