### PR TITLE
Adding SPI pins for Thunderboard Sense 2.

### DIFF
--- a/TESTS/block_device/basic/basic.cpp
+++ b/TESTS/block_device/basic/basic.cpp
@@ -71,7 +71,7 @@ void test_read_write() {
     int err = sd.init();
     TEST_ASSERT_EQUAL(0, err);
 
-    err = sd.frequency(25000000);
+    err = sd.frequency(8000000);
     TEST_ASSERT_EQUAL(0, err);
 
     for (unsigned a = 0; a < sizeof(ATTRS)/sizeof(ATTRS[0]); a++) {

--- a/config/mbed_lib.json
+++ b/config/mbed_lib.json
@@ -150,6 +150,12 @@
              "SPI_MISO": "PTE1",
              "SPI_CLK":  "PTE2",
              "SPI_CS":   "PTE4"
+        },
+        "TB_SENSE_12": {
+             "SPI_MOSI": "PC6",
+             "SPI_MISO": "PC7",
+             "SPI_CLK": "PC8",
+             "SPI_CS": "PC9"
         }
     }
 }


### PR DESCRIPTION
Thunderboard Sense 2 platfrom from SiLabs needs an external SD card adapter wired into the SPI pins on the expansion headers on the board. This is also part of the Cloud Client porting requirements. This PR adds the SPI pins for this platform.

Tested with Kingston 8GB class 4 card, SD card SPI breakout board & the Cloud Client application on the thunderboard sense 2 platform. Successful connection/registration to Cloud screenshot below:

![tb_sense_12_cloudclient_success](https://user-images.githubusercontent.com/17567812/32605625-00414238-c54a-11e7-8916-00ea72bbb854.JPG)
