### PR TITLE
FSFAT_SDCARD_INSTALLED - Accepted from mbed_app.json only

### DIFF
--- a/TESTS/block_device/basic/basic.cpp
+++ b/TESTS/block_device/basic/basic.cpp
@@ -111,7 +111,7 @@ void test_read_write() {
         // Write, sync, and read the block
         printf("test  %0*llx:%llu...\n", addrwidth, block, block_size);
 
-        err = sd.erase(block, block_size);
+        err = sd.trim(block, block_size);
         TEST_ASSERT_EQUAL(0, err);
 
         err = sd.program(write_block, block, block_size);

--- a/TESTS/filesystem/basic/basic.cpp
+++ b/TESTS/filesystem/basic/basic.cpp
@@ -90,7 +90,7 @@ using namespace utest::v1;
  *      },
  *      <<< lines removed >>>
  */
-#if defined(DEVICE_SPI) && defined(MBED_CONF_APP_FSFAT_SDCARD_INSTALLED)
+#if defined(DEVICE_SPI) && ( defined(MBED_CONF_APP_FSFAT_SDCARD_INSTALLED) || (MBED_CONF_SD_FSFAT_SDCARD_INSTALLED))
 
 #define FSFAT_BASIC_TEST_00      fsfat_basic_test_00
 #define FSFAT_BASIC_TEST_01      fsfat_basic_test_01
@@ -897,7 +897,7 @@ static control_t fsfat_basic_test_dummy()
     return CaseNext;
 }
 
-#endif  /* defined(DEVICE_SPI) && defined(MBED_CONF_APP_FSFAT_SDCARD_INSTALLED) */
+#endif
 
 utest::v1::status_t greentea_setup(const size_t number_of_cases)
 {

--- a/TESTS/filesystem/fopen/fopen.cpp
+++ b/TESTS/filesystem/fopen/fopen.cpp
@@ -75,8 +75,8 @@ using namespace utest::v1;
  *      },
  *  	<<< lines removed >>>
  */
-#if defined(DEVICE_SPI) && defined(MBED_CONF_APP_FSFAT_SDCARD_INSTALLED)
-
+ 
+#if defined(DEVICE_SPI) && ( defined(MBED_CONF_APP_FSFAT_SDCARD_INSTALLED) || (MBED_CONF_SD_FSFAT_SDCARD_INSTALLED))
 static char fsfat_fopen_utest_msg_g[FSFAT_UTEST_MSG_BUF_SIZE];
 #define FSFAT_FOPEN_TEST_MOUNT_PT_NAME      "sd"
 #define FSFAT_FOPEN_TEST_MOUNT_PT_PATH      "/"FSFAT_FOPEN_TEST_MOUNT_PT_NAME
@@ -1490,7 +1490,7 @@ static control_t fsfat_fopen_test_dummy()
     return CaseNext;
 }
 
-#endif  /* defined(DEVICE_SPI) && defined(MBED_CONF_APP_FSFAT_SDCARD_INSTALLED) */
+#endif
 
 
 /// @cond FSFAT_DOXYGEN_DISABLE


### PR DESCRIPTION
FSFAT_SDCARD_INSTALLED  if present in mbed_lib.json which is default, is not accepted by tests.
Allowing FSFAT_SDCARD_INSTALLED define from mbed_lib.json and mbed_app.json files.

Changing erase command to trim in block device test

Issue was seen in https://github.com/ARMmbed/sd-driver/pull/65