### PR TITLE
Make the code usable when the RTOS is not compiled

### DIFF
--- a/SDBlockDevice.h
+++ b/SDBlockDevice.h
@@ -28,6 +28,15 @@
 #include "BlockDevice.h"
 #include "mbed.h"
 
+/* Fake Mutex object that'll be used if the RTOS is not being compiled */
+#ifndef MBED_CONF_RTOS_PRESENT
+class Mutex {
+public:
+    void lock() {}
+    void unlock() {}
+};
+#endif // #ifndef MBED_CONF_RTOS_PRESENT
+
 
 /** Access an SD Card using SPI
  *


### PR DESCRIPTION
This code implements a fake Mutex object (that doesn't do anything)
which is only used when the RTOS is not compiled.