### PR TITLE
Block size as uint32_t gave incorrect device size

### DIFF
--- a/SDBlockDevice.cpp
+++ b/SDBlockDevice.cpp
@@ -882,7 +882,7 @@ static uint32_t ext_bits(unsigned char *data, int msb, int lsb) {
     return bits;
 }
 
-uint32_t SDBlockDevice::_sd_sectors() {
+bd_size_t SDBlockDevice::_sd_sectors() {
     uint32_t c_size, c_size_mult, read_bl_len;
     uint32_t block_len, mult, blocknr;
     uint32_t hc_c_size;

--- a/SDBlockDevice.h
+++ b/SDBlockDevice.h
@@ -189,8 +189,8 @@ private:
     uint32_t _go_idle_state();
     int _initialise_card();
 
-    uint32_t _sectors;
-    uint32_t _sd_sectors();
+    bd_size_t _sectors;
+    bd_size_t _sd_sectors();
 
     bool _is_valid_trim(bd_addr_t addr, bd_size_t size);
 
@@ -226,8 +226,8 @@ private:
     }
 
     PlatformMutex _mutex;
-    uint32_t _block_size;
-    uint32_t _erase_size;
+    bd_size_t _block_size;
+    bd_size_t _erase_size;
     bool _is_initialized;
     bool _dbg;
 };

--- a/TESTS/filesystem/fopen/fopen.cpp
+++ b/TESTS/filesystem/fopen/fopen.cpp
@@ -40,14 +40,6 @@
  * consistent values for all toolchains */
 #include "platform/mbed_retarget.h"
 
-/* This is needed for stat() test, but is not available on ARMCC.
- * The following checks whether GCC_ARM compiler is being used because:
- * - both the ARMCC compiler and the GCC_ARM compile define __GNUC__.
- * - only the ARMCC compiler defines __ARMCC_VERSION.
- * - hence if __ARMCC_VERSION is not defined and __GNUC__ is defined, it must be GCC_ARM. */
-#if ! defined(__ARMCC_VERSION) && defined(__GNUC__)
-#include <sys/stat.h>
-#endif
 using namespace utest::v1;
 
 /// @cond FSFAT_DOXYGEN_DISABLE
@@ -79,7 +71,7 @@ using namespace utest::v1;
 #if defined(DEVICE_SPI) && ( defined(MBED_CONF_APP_FSFAT_SDCARD_INSTALLED) || (MBED_CONF_SD_FSFAT_SDCARD_INSTALLED))
 static char fsfat_fopen_utest_msg_g[FSFAT_UTEST_MSG_BUF_SIZE];
 #define FSFAT_FOPEN_TEST_MOUNT_PT_NAME      "sd"
-#define FSFAT_FOPEN_TEST_MOUNT_PT_PATH      "/"FSFAT_FOPEN_TEST_MOUNT_PT_NAME
+#define FSFAT_FOPEN_TEST_MOUNT_PT_PATH      "/" FSFAT_FOPEN_TEST_MOUNT_PT_NAME
 #define FSFAT_FOPEN_TEST_WORK_BUF_SIZE_1    64
 #define FSFAT_FOPEN_TEST_FILEPATH_MAX_DEPTH 20
 static const char *sd_badfile_path = "/sd/badfile.txt";


### PR DESCRIPTION
Block size and other variables used for device size calculation are set as bd_size_t (64-bit)  instead uint32_t.