### PR TITLE
Support SD card driver on DISCO_F429ZI

### DIFF
--- a/config/mbed_lib.json
+++ b/config/mbed_lib.json
@@ -103,6 +103,12 @@
              "SPI_CLK":  "PC_10",
              "SPI_CS":   "PA_15"
          },
+         "DISCO_F429ZI": {
+            "SPI_MOSI": "PC_12",
+            "SPI_MISO": "PC_11",
+            "SPI_CLK":  "PC_10",
+            "SPI_CS":   "PA_15"
+        },
         "NUCLEO_L031K6": {
              "SPI_MOSI": "SPI_MOSI",
              "SPI_MISO": "SPI_MISO",


### PR DESCRIPTION
This PR is tested using following environment.

 - ARMmbed/mbed-cloud-client-example-internal with esp8266.
 - mbed-cloud-sdk-javascript-quickstart

