### PR TITLE
Incorrect version number was checked for non-rtos config

### DIFF
--- a/SDBlockDevice.cpp
+++ b/SDBlockDevice.cpp
@@ -148,9 +148,9 @@
 #include <errno.h>
 
 /* Required version: 5.6.1 and above */
-#ifdef MBED_MAJOR_VERSION
+#if defined(MBED_MAJOR_VERSION) && MBED_MAJOR_VERSION >= 5
 #if (MBED_VERSION < MBED_ENCODE_VERSION(5,6,1))
-#error "Incompatible mbed-os version detected! Required 5.5.4 and above"
+#error "Incompatible mbed-os version detected! Required 5.6.1 and above"
 #endif
 #else
 #warning "mbed-os version 5.6.1 or above required"


### PR DESCRIPTION
Version in mbed-os is different if RTOS is not present. Not checking the version number explicitly, but will leave the warning as few API changes were done, and tracking of version is not done for them in mbed-2.

Issue: https://github.com/ARMmbed/sd-driver/issues/76