### PR TITLE
Support SD card driver on GR_LYCHEE

### DIFF
--- a/config/mbed_lib.json
+++ b/config/mbed_lib.json
@@ -123,6 +123,12 @@
              "SPI_CLK":  "P8_3",
              "SPI_CS":   "P8_4"
         },
+        "GR_LYCHEE": {
+             "SPI_MOSI": "P5_6",
+             "SPI_MISO": "P5_7",
+             "SPI_CLK":  "P5_4",
+             "SPI_CS":   "P5_5"
+        },
         "HEXIWEAR": {
              "SPI_MOSI": "PTE3",
              "SPI_MISO": "PTE1",


### PR DESCRIPTION
I PR to support SD card driver on GR_LYCHEE that is a Renesas new mbed board.
Also I share the SD driver test result of GR_LYCHEE.
[sd-driver-test-result-GR_LYCHEE.txt](https://github.com/ARMmbed/sd-driver/files/1617776/sd-driver-test-result-GR_LYCHEE.txt)
