### PR TITLE
Add override MTB Odin target

### DIFF
--- a/config/mbed_lib.json
+++ b/config/mbed_lib.json
@@ -120,6 +120,12 @@
             "SPI_MISO": "D12",
             "SPI_CLK": "D13"
         },
+        "MTB_UBLOX_ODIN_W2": {
+            "SPI_CS": "PG_4",
+            "SPI_MOSI": "PE_14",
+            "SPI_MISO": "PE_13",
+            "SPI_CLK": "PE_12"
+       },
         "RZ_A1H": {
              "SPI_MOSI": "P8_5",
              "SPI_MISO": "P8_6",


### PR DESCRIPTION

![odin mtb backside](https://user-images.githubusercontent.com/17008964/38606979-34958e96-3d80-11e8-9ae4-0fccbe335e82.jpeg)
![odin mtb pins left](https://user-images.githubusercontent.com/17008964/38606980-34b85958-3d80-11e8-815d-3269638ca6bd.jpeg)
![odin mtb pins right](https://user-images.githubusercontent.com/17008964/38606981-34d74db8-3d80-11e8-9266-c46eee75a014.jpeg)


solve compilation error on Odin MTB target. connect to the relevant pins