### PR TITLE
Make the test for success when programming single blocks the same as …

### DIFF
--- a/SDBlockDevice.cpp
+++ b/SDBlockDevice.cpp
@@ -444,7 +444,7 @@ int SDBlockDevice::program(const void *b, bd_addr_t addr, bd_size_t size)
         response = _write(buffer, SPI_START_BLOCK, _block_size);
 
         // Only CRC and general write error are communicated via response token
-        if ((response == SPI_DATA_CRC_ERROR) || (response == SPI_DATA_WRITE_ERROR)) {
+        if (response != SPI_DATA_ACCEPTED) {
             debug_if(SD_DBG, "Single Block Write failed: 0x%x \n", response);
             status = SD_BLOCK_DEVICE_ERROR_WRITE;
         }

--- a/config/mbed_lib.json
+++ b/config/mbed_lib.json
@@ -7,7 +7,7 @@
         "SPI_CLK": "NC",
         "DEVICE_SPI": 1,
         "FSFAT_SDCARD_INSTALLED": 1,
-        "CMD_TIMEOUT": 5000,
+        "CMD_TIMEOUT": 10000,
         "CMD0_IDLE_STATE_RETRIES": 5,
         "SD_INIT_FREQUENCY": 100000
     },


### PR DESCRIPTION
…that for programming multiple blocks (i.e. the response must be `SPI_DATA_ACCEPTED`).  Otherwise a response of zero (e.g. from a slow SD card) was being treated as success.

Note that there are two commits included here, the second commit increases the default command timeout to 10 seconds in order that slower SD cards work out of the box.

The unit tests pass with just the first change and with both changes.

With just the first change:

```
mbedgt: test suite report:
+-------------------------+-----------------+-------------------------------------+--------+--------------------+-------------+
| target                  | platform_name   | test suite                          | result | elapsed_time (sec) | copy_method |
+-------------------------+-----------------+-------------------------------------+--------+--------------------+-------------+
| UBLOX_C030_U201-GCC_ARM | UBLOX_C030_U201 | sd-driver-tests-block_device-basic  | OK     | 12.53              | shell       |
| UBLOX_C030_U201-GCC_ARM | UBLOX_C030_U201 | sd-driver-tests-filesystem-basic    | OK     | 29.55              | shell       |
| UBLOX_C030_U201-GCC_ARM | UBLOX_C030_U201 | sd-driver-tests-filesystem-dirs     | OK     | 99.27              | shell       |
| UBLOX_C030_U201-GCC_ARM | UBLOX_C030_U201 | sd-driver-tests-filesystem-files    | OK     | 40.1               | shell       |
| UBLOX_C030_U201-GCC_ARM | UBLOX_C030_U201 | sd-driver-tests-filesystem-fopen    | OK     | 84.65              | shell       |
| UBLOX_C030_U201-GCC_ARM | UBLOX_C030_U201 | sd-driver-tests-filesystem-parallel | OK     | 25.05              | shell       |
| UBLOX_C030_U201-GCC_ARM | UBLOX_C030_U201 | sd-driver-tests-filesystem-seek     | OK     | 46.03              | shell       |
+-------------------------+-----------------+-------------------------------------+--------+--------------------+-------------+
mbedgt: test suite results: 7 OK
mbedgt: test case report:
+-------------------------+-----------------+-------------------------------------+----------------------------------------------------------------------------------------+--------+--------+--------+--------------------+
| target                  | platform_name   | test suite                          | test case                                                                              | passed | failed | result | elapsed_time (sec) |
+-------------------------+-----------------+-------------------------------------+----------------------------------------------------------------------------------------+--------+--------+--------+--------------------+
| UBLOX_C030_U201-GCC_ARM | UBLOX_C030_U201 | sd-driver-tests-block_device-basic  | Testing read write random blocks                                                       | 1      | 0      | OK     | 2.33               |
| UBLOX_C030_U201-GCC_ARM | UBLOX_C030_U201 | sd-driver-tests-filesystem-basic    | FSFAT_BASIC_TEST_00: fopen()/fgetc()/fprintf()/fclose() test.                          | 1      | 0      | OK     | 0.15               |
| UBLOX_C030_U201-GCC_ARM | UBLOX_C030_U201 | sd-driver-tests-filesystem-basic    | FSFAT_BASIC_TEST_01: fopen()/fseek()/fclose() test.                                    | 1      | 0      | OK     | 0.23               |
| UBLOX_C030_U201-GCC_ARM | UBLOX_C030_U201 | sd-driver-tests-filesystem-basic    | FSFAT_BASIC_TEST_03: tmpnam() test.                                                    | 1      | 0      | OK     | 0.07               |
| UBLOX_C030_U201-GCC_ARM | UBLOX_C030_U201 | sd-driver-tests-filesystem-basic    | FSFAT_BASIC_TEST_04: fileno() test.                                                    | 1      | 0      | OK     | 0.06               |
| UBLOX_C030_U201-GCC_ARM | UBLOX_C030_U201 | sd-driver-tests-filesystem-basic    | FSFAT_BASIC_TEST_05: opendir() basic test.                                             | 1      | 0      | OK     | 0.66               |
| UBLOX_C030_U201-GCC_ARM | UBLOX_C030_U201 | sd-driver-tests-filesystem-basic    | FSFAT_BASIC_TEST_06: fread()/fwrite() file to sdcard.                                  | 1      | 0      | OK     | 0.15               |
| UBLOX_C030_U201-GCC_ARM | UBLOX_C030_U201 | sd-driver-tests-filesystem-basic    | FSFAT_BASIC_TEST_07: sdcard fwrite() file test.                                        | 1      | 0      | OK     | 0.17               |
| UBLOX_C030_U201-GCC_ARM | UBLOX_C030_U201 | sd-driver-tests-filesystem-basic    | FSFAT_BASIC_TEST_08: FATFileSystem::read()/write() test.                               | 1      | 0      | OK     | 4.79               |
| UBLOX_C030_U201-GCC_ARM | UBLOX_C030_U201 | sd-driver-tests-filesystem-basic    | FSFAT_BASIC_TEST_09: POSIX FILE API fread()/fwrite() test.                             | 1      | 0      | OK     | 4.81               |
| UBLOX_C030_U201-GCC_ARM | UBLOX_C030_U201 | sd-driver-tests-filesystem-basic    | FSFAT_BASIC_TEST_10: ChanFS read()/write()) test.                                      | 1      | 0      | OK     | 4.81               |
| UBLOX_C030_U201-GCC_ARM | UBLOX_C030_U201 | sd-driver-tests-filesystem-dirs     | Directory creation                                                                     | 1      | 0      | OK     | 0.55               |
| UBLOX_C030_U201-GCC_ARM | UBLOX_C030_U201 | sd-driver-tests-filesystem-dirs     | Directory failures                                                                     | 1      | 0      | OK     | 0.1                |
| UBLOX_C030_U201-GCC_ARM | UBLOX_C030_U201 | sd-driver-tests-filesystem-dirs     | Directory iteration                                                                    | 1      | 0      | OK     | 0.1                |
| UBLOX_C030_U201-GCC_ARM | UBLOX_C030_U201 | sd-driver-tests-filesystem-dirs     | Directory remove                                                                       | 1      | 0      | OK     | 0.4                |
| UBLOX_C030_U201-GCC_ARM | UBLOX_C030_U201 | sd-driver-tests-filesystem-dirs     | Directory rename                                                                       | 1      | 0      | OK     | 3.97               |
| UBLOX_C030_U201-GCC_ARM | UBLOX_C030_U201 | sd-driver-tests-filesystem-dirs     | Directory tests                                                                        | 1      | 0      | OK     | 13.47              |
| UBLOX_C030_U201-GCC_ARM | UBLOX_C030_U201 | sd-driver-tests-filesystem-dirs     | File creation                                                                          | 1      | 0      | OK     | 0.1                |
| UBLOX_C030_U201-GCC_ARM | UBLOX_C030_U201 | sd-driver-tests-filesystem-dirs     | Multi-block directory                                                                  | 1      | 0      | OK     | 66.58              |
| UBLOX_C030_U201-GCC_ARM | UBLOX_C030_U201 | sd-driver-tests-filesystem-dirs     | Nested directories                                                                     | 1      | 0      | OK     | 1.54               |
| UBLOX_C030_U201-GCC_ARM | UBLOX_C030_U201 | sd-driver-tests-filesystem-dirs     | Root directory                                                                         | 1      | 0      | OK     | 0.09               |
| UBLOX_C030_U201-GCC_ARM | UBLOX_C030_U201 | sd-driver-tests-filesystem-files    | Block Size file test                                                                   | 1      | 0      | OK     | 0.6                |
| UBLOX_C030_U201-GCC_ARM | UBLOX_C030_U201 | sd-driver-tests-filesystem-files    | Dir check                                                                              | 1      | 0      | OK     | 0.08               |
| UBLOX_C030_U201-GCC_ARM | UBLOX_C030_U201 | sd-driver-tests-filesystem-files    | File tests                                                                             | 1      | 0      | OK     | 13.46              |
| UBLOX_C030_U201-GCC_ARM | UBLOX_C030_U201 | sd-driver-tests-filesystem-files    | Large file test                                                                        | 1      | 0      | OK     | 8.17               |
| UBLOX_C030_U201-GCC_ARM | UBLOX_C030_U201 | sd-driver-tests-filesystem-files    | Medium file test                                                                       | 1      | 0      | OK     | 0.42               |
| UBLOX_C030_U201-GCC_ARM | UBLOX_C030_U201 | sd-driver-tests-filesystem-files    | Multiple block size file test                                                          | 1      | 0      | OK     | 0.92               |
| UBLOX_C030_U201-GCC_ARM | UBLOX_C030_U201 | sd-driver-tests-filesystem-files    | Non-overlap check                                                                      | 1      | 0      | OK     | 4.02               |
| UBLOX_C030_U201-GCC_ARM | UBLOX_C030_U201 | sd-driver-tests-filesystem-files    | Simple file test                                                                       | 1      | 0      | OK     | 0.17               |
| UBLOX_C030_U201-GCC_ARM | UBLOX_C030_U201 | sd-driver-tests-filesystem-files    | Small file test                                                                        | 1      | 0      | OK     | 0.2                |
| UBLOX_C030_U201-GCC_ARM | UBLOX_C030_U201 | sd-driver-tests-filesystem-fopen    | FSFAT_FOPEN_TEST_01: fopen()/fwrite()/fclose() directories/file in multi-dir filepath. | 1      | 0      | OK     | 3.65               |
| UBLOX_C030_U201-GCC_ARM | UBLOX_C030_U201 | sd-driver-tests-filesystem-fopen    | FSFAT_FOPEN_TEST_02: fopen(r) pre-existing file try to write it.                       | 1      | 0      | OK     | 0.15               |
| UBLOX_C030_U201-GCC_ARM | UBLOX_C030_U201 | sd-driver-tests-filesystem-fopen    | FSFAT_FOPEN_TEST_03: fopen(w+) pre-existing file try to write it.                      | 1      | 0      | OK     | 0.29               |
| UBLOX_C030_U201-GCC_ARM | UBLOX_C030_U201 | sd-driver-tests-filesystem-fopen    | FSFAT_FOPEN_TEST_04: fopen() with a filename exceeding the maximum length.             | 1      | 0      | OK     | 0.11               |
| UBLOX_C030_U201-GCC_ARM | UBLOX_C030_U201 | sd-driver-tests-filesystem-fopen    | FSFAT_FOPEN_TEST_06: fopen() with bad filenames (minimal).                             | 1      | 0      | OK     | 0.1                |
| UBLOX_C030_U201-GCC_ARM | UBLOX_C030_U201 | sd-driver-tests-filesystem-fopen    | FSFAT_FOPEN_TEST_07: fopen()/errno handling.                                           | 1      | 0      | OK     | 0.07               |
| UBLOX_C030_U201-GCC_ARM | UBLOX_C030_U201 | sd-driver-tests-filesystem-fopen    | FSFAT_FOPEN_TEST_08: ferror()/clearerr()/errno handling.                               | 1      | 0      | OK     | 0.1                |
| UBLOX_C030_U201-GCC_ARM | UBLOX_C030_U201 | sd-driver-tests-filesystem-fopen    | FSFAT_FOPEN_TEST_09: ftell() handling.                                                 | 1      | 0      | OK     | 0.12               |
| UBLOX_C030_U201-GCC_ARM | UBLOX_C030_U201 | sd-driver-tests-filesystem-fopen    | FSFAT_FOPEN_TEST_10: remove() test.                                                    | 1      | 0      | OK     | 0.7                |
| UBLOX_C030_U201-GCC_ARM | UBLOX_C030_U201 | sd-driver-tests-filesystem-fopen    | FSFAT_FOPEN_TEST_11: rename().                                                         | 1      | 0      | OK     | 1.14               |
| UBLOX_C030_U201-GCC_ARM | UBLOX_C030_U201 | sd-driver-tests-filesystem-fopen    | FSFAT_FOPEN_TEST_12: opendir(), readdir(), closedir() test.                            | 1      | 0      | OK     | 1.77               |
| UBLOX_C030_U201-GCC_ARM | UBLOX_C030_U201 | sd-driver-tests-filesystem-fopen    | FSFAT_FOPEN_TEST_13: mkdir() test.                                                     | 1      | 0      | OK     | 0.62               |
| UBLOX_C030_U201-GCC_ARM | UBLOX_C030_U201 | sd-driver-tests-filesystem-fopen    | FSFAT_FOPEN_TEST_14: stat() test.                                                      | 1      | 0      | OK     | 0.74               |
| UBLOX_C030_U201-GCC_ARM | UBLOX_C030_U201 | sd-driver-tests-filesystem-fopen    | FSFAT_FOPEN_TEST_15: format() test.                                                    | 1      | 0      | OK     | 13.5               |
| UBLOX_C030_U201-GCC_ARM | UBLOX_C030_U201 | sd-driver-tests-filesystem-fopen    | FSFAT_FOPEN_TEST_16: write/check n x 25kB data files.                                  | 1      | 0      | OK     | 45.85              |
| UBLOX_C030_U201-GCC_ARM | UBLOX_C030_U201 | sd-driver-tests-filesystem-parallel | File tests                                                                             | 1      | 0      | OK     | 13.45              |
| UBLOX_C030_U201-GCC_ARM | UBLOX_C030_U201 | sd-driver-tests-filesystem-parallel | Filesystem access from multiple threads                                                | 1      | 0      | OK     | 0.7                |
| UBLOX_C030_U201-GCC_ARM | UBLOX_C030_U201 | sd-driver-tests-filesystem-seek     | Boundary seek and write                                                                | 1      | 0      | OK     | 0.47               |
| UBLOX_C030_U201-GCC_ARM | UBLOX_C030_U201 | sd-driver-tests-filesystem-seek     | Large dir seek                                                                         | 1      | 0      | OK     | 0.23               |
| UBLOX_C030_U201-GCC_ARM | UBLOX_C030_U201 | sd-driver-tests-filesystem-seek     | Large file seek                                                                        | 1      | 0      | OK     | 0.15               |
| UBLOX_C030_U201-GCC_ARM | UBLOX_C030_U201 | sd-driver-tests-filesystem-seek     | Large file seek and write                                                              | 1      | 0      | OK     | 0.19               |
| UBLOX_C030_U201-GCC_ARM | UBLOX_C030_U201 | sd-driver-tests-filesystem-seek     | Out-of-bounds seek                                                                     | 1      | 0      | OK     | 0.15               |
| UBLOX_C030_U201-GCC_ARM | UBLOX_C030_U201 | sd-driver-tests-filesystem-seek     | Seek tests                                                                             | 1      | 0      | OK     | 32.17              |
| UBLOX_C030_U201-GCC_ARM | UBLOX_C030_U201 | sd-driver-tests-filesystem-seek     | Simple dir seek                                                                        | 1      | 0      | OK     | 0.1                |
| UBLOX_C030_U201-GCC_ARM | UBLOX_C030_U201 | sd-driver-tests-filesystem-seek     | Simple file seek                                                                       | 1      | 0      | OK     | 0.14               |
| UBLOX_C030_U201-GCC_ARM | UBLOX_C030_U201 | sd-driver-tests-filesystem-seek     | Simple file seek and write                                                             | 1      | 0      | OK     | 0.18               |
+-------------------------+-----------------+-------------------------------------+----------------------------------------------------------------------------------------+--------+--------+--------+--------------------+
mbedgt: test case results: 56 OK
mbedgt: completed in 337.39 sec
```

With both changes (using the slow SD card):

```
mbedgt: test suite report:
+-------------------------+-----------------+-------------------------------------+--------+--------------------+-------------+
| target                  | platform_name   | test suite                          | result | elapsed_time (sec) | copy_method |
+-------------------------+-----------------+-------------------------------------+--------+--------------------+-------------+
| UBLOX_C030_U201-GCC_ARM | UBLOX_C030_U201 | sd-driver-tests-block_device-basic  | OK     | 12.63              | shell       |
| UBLOX_C030_U201-GCC_ARM | UBLOX_C030_U201 | sd-driver-tests-filesystem-basic    | OK     | 31.83              | shell       |
| UBLOX_C030_U201-GCC_ARM | UBLOX_C030_U201 | sd-driver-tests-filesystem-dirs     | OK     | 128.72             | shell       |
| UBLOX_C030_U201-GCC_ARM | UBLOX_C030_U201 | sd-driver-tests-filesystem-files    | OK     | 67.44              | shell       |
| UBLOX_C030_U201-GCC_ARM | UBLOX_C030_U201 | sd-driver-tests-filesystem-fopen    | OK     | 114.5              | shell       |
| UBLOX_C030_U201-GCC_ARM | UBLOX_C030_U201 | sd-driver-tests-filesystem-parallel | OK     | 52.08              | shell       |
| UBLOX_C030_U201-GCC_ARM | UBLOX_C030_U201 | sd-driver-tests-filesystem-seek     | OK     | 73.85              | shell       |
+-------------------------+-----------------+-------------------------------------+--------+--------------------+-------------+
mbedgt: test suite results: 7 OK
mbedgt: test case report:
+-------------------------+-----------------+-------------------------------------+----------------------------------------------------------------------------------------+--------+--------+--------+--------------------+
| target                  | platform_name   | test suite                          | test case                                                                              | passed | failed | result | elapsed_time (sec) |
+-------------------------+-----------------+-------------------------------------+----------------------------------------------------------------------------------------+--------+--------+--------+--------------------+
| UBLOX_C030_U201-GCC_ARM | UBLOX_C030_U201 | sd-driver-tests-block_device-basic  | Testing read write random blocks                                                       | 1      | 0      | OK     | 2.43               |
| UBLOX_C030_U201-GCC_ARM | UBLOX_C030_U201 | sd-driver-tests-filesystem-basic    | FSFAT_BASIC_TEST_00: fopen()/fgetc()/fprintf()/fclose() test.                          | 1      | 0      | OK     | 0.18               |
| UBLOX_C030_U201-GCC_ARM | UBLOX_C030_U201 | sd-driver-tests-filesystem-basic    | FSFAT_BASIC_TEST_01: fopen()/fseek()/fclose() test.                                    | 1      | 0      | OK     | 0.25               |
| UBLOX_C030_U201-GCC_ARM | UBLOX_C030_U201 | sd-driver-tests-filesystem-basic    | FSFAT_BASIC_TEST_03: tmpnam() test.                                                    | 1      | 0      | OK     | 0.09               |
| UBLOX_C030_U201-GCC_ARM | UBLOX_C030_U201 | sd-driver-tests-filesystem-basic    | FSFAT_BASIC_TEST_04: fileno() test.                                                    | 1      | 0      | OK     | 0.08               |
| UBLOX_C030_U201-GCC_ARM | UBLOX_C030_U201 | sd-driver-tests-filesystem-basic    | FSFAT_BASIC_TEST_05: opendir() basic test.                                             | 1      | 0      | OK     | 0.71               |
| UBLOX_C030_U201-GCC_ARM | UBLOX_C030_U201 | sd-driver-tests-filesystem-basic    | FSFAT_BASIC_TEST_06: fread()/fwrite() file to sdcard.                                  | 1      | 0      | OK     | 0.15               |
| UBLOX_C030_U201-GCC_ARM | UBLOX_C030_U201 | sd-driver-tests-filesystem-basic    | FSFAT_BASIC_TEST_07: sdcard fwrite() file test.                                        | 1      | 0      | OK     | 0.19               |
| UBLOX_C030_U201-GCC_ARM | UBLOX_C030_U201 | sd-driver-tests-filesystem-basic    | FSFAT_BASIC_TEST_08: FATFileSystem::read()/write() test.                               | 1      | 0      | OK     | 5.47               |
| UBLOX_C030_U201-GCC_ARM | UBLOX_C030_U201 | sd-driver-tests-filesystem-basic    | FSFAT_BASIC_TEST_09: POSIX FILE API fread()/fwrite() test.                             | 1      | 0      | OK     | 5.56               |
| UBLOX_C030_U201-GCC_ARM | UBLOX_C030_U201 | sd-driver-tests-filesystem-basic    | FSFAT_BASIC_TEST_10: ChanFS read()/write()) test.                                      | 1      | 0      | OK     | 5.52               |
| UBLOX_C030_U201-GCC_ARM | UBLOX_C030_U201 | sd-driver-tests-filesystem-dirs     | Directory creation                                                                     | 1      | 0      | OK     | 0.55               |
| UBLOX_C030_U201-GCC_ARM | UBLOX_C030_U201 | sd-driver-tests-filesystem-dirs     | Directory failures                                                                     | 1      | 0      | OK     | 0.07               |
| UBLOX_C030_U201-GCC_ARM | UBLOX_C030_U201 | sd-driver-tests-filesystem-dirs     | Directory iteration                                                                    | 1      | 0      | OK     | 0.09               |
| UBLOX_C030_U201-GCC_ARM | UBLOX_C030_U201 | sd-driver-tests-filesystem-dirs     | Directory remove                                                                       | 1      | 0      | OK     | 0.37               |
| UBLOX_C030_U201-GCC_ARM | UBLOX_C030_U201 | sd-driver-tests-filesystem-dirs     | Directory rename                                                                       | 1      | 0      | OK     | 3.98               |
| UBLOX_C030_U201-GCC_ARM | UBLOX_C030_U201 | sd-driver-tests-filesystem-dirs     | Directory tests                                                                        | 1      | 0      | OK     | 40.53              |
| UBLOX_C030_U201-GCC_ARM | UBLOX_C030_U201 | sd-driver-tests-filesystem-dirs     | File creation                                                                          | 1      | 0      | OK     | 0.08               |
| UBLOX_C030_U201-GCC_ARM | UBLOX_C030_U201 | sd-driver-tests-filesystem-dirs     | Multi-block directory                                                                  | 1      | 0      | OK     | 68.37              |
| UBLOX_C030_U201-GCC_ARM | UBLOX_C030_U201 | sd-driver-tests-filesystem-dirs     | Nested directories                                                                     | 1      | 0      | OK     | 1.53               |
| UBLOX_C030_U201-GCC_ARM | UBLOX_C030_U201 | sd-driver-tests-filesystem-dirs     | Root directory                                                                         | 1      | 0      | OK     | 0.07               |
| UBLOX_C030_U201-GCC_ARM | UBLOX_C030_U201 | sd-driver-tests-filesystem-files    | Block Size file test                                                                   | 1      | 0      | OK     | 0.61               |
| UBLOX_C030_U201-GCC_ARM | UBLOX_C030_U201 | sd-driver-tests-filesystem-files    | Dir check                                                                              | 1      | 0      | OK     | 0.06               |
| UBLOX_C030_U201-GCC_ARM | UBLOX_C030_U201 | sd-driver-tests-filesystem-files    | File tests                                                                             | 1      | 0      | OK     | 40.48              |
| UBLOX_C030_U201-GCC_ARM | UBLOX_C030_U201 | sd-driver-tests-filesystem-files    | Large file test                                                                        | 1      | 0      | OK     | 8.48               |
| UBLOX_C030_U201-GCC_ARM | UBLOX_C030_U201 | sd-driver-tests-filesystem-files    | Medium file test                                                                       | 1      | 0      | OK     | 0.4                |
| UBLOX_C030_U201-GCC_ARM | UBLOX_C030_U201 | sd-driver-tests-filesystem-files    | Multiple block size file test                                                          | 1      | 0      | OK     | 0.93               |
| UBLOX_C030_U201-GCC_ARM | UBLOX_C030_U201 | sd-driver-tests-filesystem-files    | Non-overlap check                                                                      | 1      | 0      | OK     | 4.06               |
| UBLOX_C030_U201-GCC_ARM | UBLOX_C030_U201 | sd-driver-tests-filesystem-files    | Simple file test                                                                       | 1      | 0      | OK     | 0.14               |
| UBLOX_C030_U201-GCC_ARM | UBLOX_C030_U201 | sd-driver-tests-filesystem-files    | Small file test                                                                        | 1      | 0      | OK     | 0.17               |
| UBLOX_C030_U201-GCC_ARM | UBLOX_C030_U201 | sd-driver-tests-filesystem-fopen    | FSFAT_FOPEN_TEST_01: fopen()/fwrite()/fclose() directories/file in multi-dir filepath. | 1      | 0      | OK     | 3.74               |
| UBLOX_C030_U201-GCC_ARM | UBLOX_C030_U201 | sd-driver-tests-filesystem-fopen    | FSFAT_FOPEN_TEST_02: fopen(r) pre-existing file try to write it.                       | 1      | 0      | OK     | 0.17               |
| UBLOX_C030_U201-GCC_ARM | UBLOX_C030_U201 | sd-driver-tests-filesystem-fopen    | FSFAT_FOPEN_TEST_03: fopen(w+) pre-existing file try to write it.                      | 1      | 0      | OK     | 0.32               |
| UBLOX_C030_U201-GCC_ARM | UBLOX_C030_U201 | sd-driver-tests-filesystem-fopen    | FSFAT_FOPEN_TEST_04: fopen() with a filename exceeding the maximum length.             | 1      | 0      | OK     | 0.11               |
| UBLOX_C030_U201-GCC_ARM | UBLOX_C030_U201 | sd-driver-tests-filesystem-fopen    | FSFAT_FOPEN_TEST_06: fopen() with bad filenames (minimal).                             | 1      | 0      | OK     | 0.1                |
| UBLOX_C030_U201-GCC_ARM | UBLOX_C030_U201 | sd-driver-tests-filesystem-fopen    | FSFAT_FOPEN_TEST_07: fopen()/errno handling.                                           | 1      | 0      | OK     | 0.08               |
| UBLOX_C030_U201-GCC_ARM | UBLOX_C030_U201 | sd-driver-tests-filesystem-fopen    | FSFAT_FOPEN_TEST_08: ferror()/clearerr()/errno handling.                               | 1      | 0      | OK     | 0.09               |
| UBLOX_C030_U201-GCC_ARM | UBLOX_C030_U201 | sd-driver-tests-filesystem-fopen    | FSFAT_FOPEN_TEST_09: ftell() handling.                                                 | 1      | 0      | OK     | 0.13               |
| UBLOX_C030_U201-GCC_ARM | UBLOX_C030_U201 | sd-driver-tests-filesystem-fopen    | FSFAT_FOPEN_TEST_10: remove() test.                                                    | 1      | 0      | OK     | 0.73               |
| UBLOX_C030_U201-GCC_ARM | UBLOX_C030_U201 | sd-driver-tests-filesystem-fopen    | FSFAT_FOPEN_TEST_11: rename().                                                         | 1      | 0      | OK     | 1.14               |
| UBLOX_C030_U201-GCC_ARM | UBLOX_C030_U201 | sd-driver-tests-filesystem-fopen    | FSFAT_FOPEN_TEST_12: opendir(), readdir(), closedir() test.                            | 1      | 0      | OK     | 1.89               |
| UBLOX_C030_U201-GCC_ARM | UBLOX_C030_U201 | sd-driver-tests-filesystem-fopen    | FSFAT_FOPEN_TEST_13: mkdir() test.                                                     | 1      | 0      | OK     | 0.65               |
| UBLOX_C030_U201-GCC_ARM | UBLOX_C030_U201 | sd-driver-tests-filesystem-fopen    | FSFAT_FOPEN_TEST_14: stat() test.                                                      | 1      | 0      | OK     | 0.76               |
| UBLOX_C030_U201-GCC_ARM | UBLOX_C030_U201 | sd-driver-tests-filesystem-fopen    | FSFAT_FOPEN_TEST_15: format() test.                                                    | 1      | 0      | OK     | 40.43              |
| UBLOX_C030_U201-GCC_ARM | UBLOX_C030_U201 | sd-driver-tests-filesystem-fopen    | FSFAT_FOPEN_TEST_16: write/check n x 25kB data files.                                  | 1      | 0      | OK     | 48.64              |
| UBLOX_C030_U201-GCC_ARM | UBLOX_C030_U201 | sd-driver-tests-filesystem-parallel | File tests                                                                             | 1      | 0      | OK     | 40.44              |
| UBLOX_C030_U201-GCC_ARM | UBLOX_C030_U201 | sd-driver-tests-filesystem-parallel | Filesystem access from multiple threads                                                | 1      | 0      | OK     | 0.74               |
| UBLOX_C030_U201-GCC_ARM | UBLOX_C030_U201 | sd-driver-tests-filesystem-seek     | Boundary seek and write                                                                | 1      | 0      | OK     | 0.45               |
| UBLOX_C030_U201-GCC_ARM | UBLOX_C030_U201 | sd-driver-tests-filesystem-seek     | Large dir seek                                                                         | 1      | 0      | OK     | 0.2                |
| UBLOX_C030_U201-GCC_ARM | UBLOX_C030_U201 | sd-driver-tests-filesystem-seek     | Large file seek                                                                        | 1      | 0      | OK     | 0.13               |
| UBLOX_C030_U201-GCC_ARM | UBLOX_C030_U201 | sd-driver-tests-filesystem-seek     | Large file seek and write                                                              | 1      | 0      | OK     | 0.16               |
| UBLOX_C030_U201-GCC_ARM | UBLOX_C030_U201 | sd-driver-tests-filesystem-seek     | Out-of-bounds seek                                                                     | 1      | 0      | OK     | 0.13               |
| UBLOX_C030_U201-GCC_ARM | UBLOX_C030_U201 | sd-driver-tests-filesystem-seek     | Seek tests                                                                             | 1      | 0      | OK     | 60.24              |
| UBLOX_C030_U201-GCC_ARM | UBLOX_C030_U201 | sd-driver-tests-filesystem-seek     | Simple dir seek                                                                        | 1      | 0      | OK     | 0.09               |
| UBLOX_C030_U201-GCC_ARM | UBLOX_C030_U201 | sd-driver-tests-filesystem-seek     | Simple file seek                                                                       | 1      | 0      | OK     | 0.1                |
| UBLOX_C030_U201-GCC_ARM | UBLOX_C030_U201 | sd-driver-tests-filesystem-seek     | Simple file seek and write                                                             | 1      | 0      | OK     | 0.13               |
+-------------------------+-----------------+-------------------------------------+----------------------------------------------------------------------------------------+--------+--------+--------+--------------------+
mbedgt: test case results: 56 OK
mbedgt: completed in 481.32 sec
```