### PR TITLE
Updating timeouts as per SD Spec - Do not merge

### DIFF
--- a/config/mbed_lib.json
+++ b/config/mbed_lib.json
@@ -7,8 +7,8 @@
         "SPI_CLK": "NC",
         "DEVICE_SPI": 1,
         "FSFAT_SDCARD_INSTALLED": 1,
-        "CMD_TIMEOUT": 10000,
-        "CMD0_IDLE_STATE_RETRIES": 5,
+        "CMD_TIMEOUT": 1200,
+        "CMD0_IDLE_STATE_RETRIES": 3,
         "SD_INIT_FREQUENCY": 100000
     },
     "target_overrides": {


### PR DESCRIPTION
Command / Read / Write / Erase / Init timeouts should be different as per the SD Specification.
Single macro is used for all timeout condition, which causes huge delay in case SD card is not present.

Extra delay in timeout wont case any problem with normal SD card operation, but it card is not detected it will stall the system for long (50 sec).

TODO: PR is not tested
