### PR TITLE
Add init reference count

### DIFF
--- a/SDBlockDevice.h
+++ b/SDBlockDevice.h
@@ -226,6 +226,7 @@ private:
     bool _is_initialized;
     bool _dbg;
     bool _crc_on;
+    uint32_t _init_ref_count;
 
     MbedCRC<POLY_7BIT_SD, 7> _crc7;
     MbedCRC<POLY_16BIT_CCITT, 16> _crc16;


### PR DESCRIPTION
This PR fixes the problem of multiple calls to BD init/deinit APIs, by simply adding an init ref count. This is required due to the fact that the mbed-os utility block devices, which may use SD block device as the backing block device, call the underlying init/deinit APIs automatically. 
This PR resolves [#7455](https://github.com/ARMmbed/mbed-os/issues/7455) for the SD block device.