### PR TITLE
Fix wrong PIN config for RTL8195AM platform

### DIFF
--- a/config/mbed_lib.json
+++ b/config/mbed_lib.json
@@ -208,7 +208,7 @@
             "SPI_MOSI": "D11",
             "SPI_MISO": "D12",
             "SPI_CLK": "D13",
-            "SPI_CS": "D9"
+            "SPI_CS": "D10"
         }
     }
 }


### PR DESCRIPTION
For realtek RTL8195AM platform. 
The correct PIN for SPI-CS should be D10. 

