### PR TITLE
Adding deprecation warning for mbed-os 5.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 # Warning
 Starting from mbed-os 5.10 this repository is deprecated. 
-Please refer to mbed-os 5.10 documentation for more detail on how to enable SD support.
+Please refer to mbed-os 5.10 [documentation](https://github.com/ARMmbed/mbed-os-5-docs/blob/development/docs/api/storage/SDBlockDevice.md) and [code](https://github.com/ARMmbed/mbed-os/tree/master/components/storage/blockdevice/COMPONENT_SD) for more detail regarding how to enable SD support.
 
 
 Simon Hughes

--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # mbed OS SDCard Driver (sd-driver) for FAT32 Filesystem Support
 
 
+# Warning
+Starting from mbed-os 5.10 this repository is deprecated. 
+Please refer to mbed-os 5.10 documentation for more detail on how to enable SD support.
+
+
 Simon Hughes
 
 20170329

--- a/SDBlockDevice.cpp
+++ b/SDBlockDevice.cpp
@@ -151,10 +151,10 @@
 #warning "mbed-os version 5.9.0 or above required"
 #endif
 
-/* Started from version 5.10.0 SDBlockDevice external repo is depricated. 
+/* Started from version 5.10.0 SDBlockDevice external repo is deprecated. 
    please use the SDBlockDevice component inside mbed-os.*/
 #if defined(MBED_MAJOR_VERSION) && MBED_MAJOR_VERSION >= 5 && (MBED_VERSION >= MBED_ENCODE_VERSION(5,10,0))
-#error "Started from version 5.10.0 SDBlockDevice external repo is depricated. please use the SDBlockDevice component inside mbed-os."
+#error "Started from version 5.10.0 SDBlockDevice external repo is deprecated. please use the SDBlockDevice component inside mbed-os."
 #endif
 
 #ifndef MBED_CONF_SD_CMD_TIMEOUT

--- a/SDBlockDevice.cpp
+++ b/SDBlockDevice.cpp
@@ -151,6 +151,12 @@
 #warning "mbed-os version 5.9.0 or above required"
 #endif
 
+/* Started from version 5.10.0 SDBlockDevice external repo is depricated. 
+   please use the SDBlockDevice component inside mbed-os.*/
+#if defined(MBED_MAJOR_VERSION) && MBED_MAJOR_VERSION >= 5 && (MBED_VERSION >= MBED_ENCODE_VERSION(5,10,0))
+#error "Started from version 5.10.0 SDBlockDevice external repo is depricated. please use the SDBlockDevice component inside mbed-os."
+#endif
+
 #ifndef MBED_CONF_SD_CMD_TIMEOUT
 #define MBED_CONF_SD_CMD_TIMEOUT                 5000   /*!< Timeout in ms for response */
 #endif


### PR DESCRIPTION
Starting mbed-os 5.10 the SD driver has moved into mbed-os.
Therefore this PR is adding a warning in the SD documentation for the incoming depreciation. 

This PR is dependent on PR #7774
https://github.com/ARMmbed/mbed-os/pull/7774

